### PR TITLE
Load Swift in a separate thread

### DIFF
--- a/android/app/src/main/java/com/readdle/weather/WeatherApp.kt
+++ b/android/app/src/main/java/com/readdle/weather/WeatherApp.kt
@@ -22,7 +22,7 @@ class WeatherApp: Application() {
             sleep = false
         }
         while (sleep) {
-            Log.d("breezeApp", "sleeping")
+            //wait for Swift to be setup
         }
     }
 


### PR DESCRIPTION
In order for DispatchQueue.main not to deadlock, Swift needs to be initiated on a bg-thread. This is needed when calling e.g. DispatchQueue.main.async, etc. 

At least this is my current working theory! :)